### PR TITLE
Fix for below 0C measurements with nominal resistance other than 100 ohms

### DIFF
--- a/adafruit_max31865.py
+++ b/adafruit_max31865.py
@@ -244,6 +244,11 @@ class MAX31865:
         temp = (math.sqrt(temp) + Z1) / Z4
         if temp >= 0:
             return temp
+
+        # For the following math to work, nominal RTD resistance must be normalized to 100 ohms
+        raw_reading /= self.rtd_nominal
+        raw_reading *= 100
+
         rpoly = raw_reading
         temp = -242.02
         temp += 2.2228 * rpoly


### PR DESCRIPTION
This fix is based on the Adafruit C++ library for the MAX31865

https://github.com/adafruit/Adafruit_MAX31865/blob/master/Adafruit_MAX31865.cpp