### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_max31865.py
+++ b/adafruit_max31865.py
@@ -58,7 +58,6 @@ import adafruit_bus_device.spi_device as spi_device
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MAX31865.git"
 
-# pylint: disable=bad-whitespace
 # Register and other constant values:
 _MAX31865_CONFIG_REG = const(0x00)
 _MAX31865_CONFIG_BIAS = const(0x80)
@@ -85,7 +84,6 @@ _MAX31865_FAULT_RTDINLOW = const(0x08)
 _MAX31865_FAULT_OVUV = const(0x04)
 _RTD_A = 3.9083e-3
 _RTD_B = -5.775e-7
-# pylint: enable=bad-whitespace
 
 
 class MAX31865:
@@ -203,14 +201,12 @@ class MAX31865:
         - OVUV
         """
         faults = self._read_u8(_MAX31865_FAULTSTAT_REG)
-        # pylint: disable=bad-whitespace
         highthresh = bool(faults & _MAX31865_FAULT_HIGHTHRESH)
         lowthresh = bool(faults & _MAX31865_FAULT_LOWTHRESH)
         refinlow = bool(faults & _MAX31865_FAULT_REFINLOW)
         refinhigh = bool(faults & _MAX31865_FAULT_REFINHIGH)
         rtdinlow = bool(faults & _MAX31865_FAULT_RTDINLOW)
         ovuv = bool(faults & _MAX31865_FAULT_OVUV)
-        # pylint: enable=bad-whitespace
         return (highthresh, lowthresh, refinlow, refinhigh, rtdinlow, ovuv)
 
     def clear_faults(self):


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.