### PR TITLE
auto_convert: set/unset bias, + use in read_rtd

### DIFF
--- a/adafruit_max31865.py
+++ b/adafruit_max31865.py
@@ -204,8 +204,10 @@ class MAX31865:
         config = self._read_u8(_MAX31865_CONFIG_REG)
         if val:
             config |= _MAX31865_CONFIG_MODEAUTO  # Enable auto convert.
+            config |= _MAX31865_CONFIG_BIAS  # Enable bias.
         else:
             config &= ~_MAX31865_CONFIG_MODEAUTO  # Disable auto convert.
+            config &= ~_MAX31865_CONFIG_BIAS  # Disable bias.
         self._write_u8(_MAX31865_CONFIG_REG, config)
 
     @property
@@ -243,6 +245,11 @@ class MAX31865:
         nominal value of the resistance-to-digital conversion and some math.  If you just want
         temperature use the temperature property instead.
         """
+        if self.auto_convert:
+            rtd = self._read_u16(_MAX31865_RTDMSB_REG)
+            if not rtd & 1:
+                rtd >>= 1
+                return rtd
         self.clear_faults()
         self.bias = True
         time.sleep(0.01)


### PR DESCRIPTION
I was able to enable auto_convert with this small patch:
 - enable the bias when setting the auto_convert mode
 - in `read_rtd`, actually use the auto conversion functionality.

This should alleviate the concern raised by #28

Source: https://datasheets.maximintegrated.com/en/ds/MAX31865.pdf , which says:

> When automatic (continuous) conversion
mode is selected, VBIAS remains on continuously

Actually, I observed that the microcontroller must set VBIAS by itself, the device doesn't seem to do it automagically. If VBIAS is not set by the microcontroller, then there is no continuous update of the resistance readings
